### PR TITLE
Fix warnings.

### DIFF
--- a/ios/project/Plugins/WizViewManagerPlugin/WizViewManagerPlugin.m
+++ b/ios/project/Plugins/WizViewManagerPlugin/WizViewManagerPlugin.m
@@ -896,6 +896,7 @@ static WizViewManagerPlugin * wizViewManagerInstance = NULL;
        
         if ([viewType isEqualToString:@"webview"]) {
             
+            // Get the view from the view list
             UIWebView *targetWebView = [wizViewList objectForKey:viewName];
             
             // remove the view!
@@ -906,11 +907,11 @@ static WizViewManagerPlugin * wizViewManagerInstance = NULL;
             
         } else if ([viewType isEqualToString:@"canvas"]) {
             
-            // Message canvas view
+            // Get the view from the view list
             WizCanvasView *targetCanvasView = [wizViewList objectForKey:viewName];
             
             // remove the view!
-            [targetCanvasView removeFromSuperview];
+            [targetCanvasView.window removeFromSuperview];
             [targetCanvasView release];
 //             targetCanvasView.window.delegate = nil;
             targetCanvasView = nil;


### PR DESCRIPTION
- Removed some bad code that was attempting to remove a view controller from a
  view.  This eliminates a warning.  However, the surrounding code should be
  re-examined carefully -- the comments not match the code and it is actually
  unclear what the purpose of the code block is.  It looks like the code should
  remove the canvas view from the dictionary, but that is not actually what the
  code is doing.  It seems to merely decrease the reference count which may
  result in the canvas view's reference count dropping to zero before it is
  removed from the dictionary.

Reviewer: @aogilvie
