### PR TITLE
Changed EJTimer implementation to work with compiler optimizations.

### DIFF
--- a/ios/project/Plugins/WizViewManagerPlugin/Ejecta/EJTimer.h
+++ b/ios/project/Plugins/WizViewManagerPlugin/Ejecta/EJTimer.h
@@ -14,8 +14,7 @@
 
 
 @interface EJTimer : NSObject {
-	NSTimeInterval target;
-	float interval;
+	NSTimeInterval interval;
 	JSObjectRef callback;
 	BOOL active, repeat;
 }

--- a/ios/project/Plugins/WizViewManagerPlugin/Ejecta/EJTimer.m
+++ b/ios/project/Plugins/WizViewManagerPlugin/Ejecta/EJTimer.m
@@ -6,6 +6,7 @@
 - (id)init {
 	if( self = [super init] ) {
 		timers = [[NSMutableDictionary alloc] init];
+        lastId = 0;
 	}
 	return self;
 }
@@ -43,6 +44,10 @@
 
 
 
+@interface EJTimer()
+@property (nonatomic, retain) NSDate *target;
+@end
+
 @implementation EJTimer
 @synthesize active;
 
@@ -51,7 +56,7 @@
 		active = true;
 		interval = intervalp;
 		repeat = repeatp;
-		target = [NSDate timeIntervalSinceReferenceDate] + interval;
+		self.target = [NSDate dateWithTimeIntervalSinceNow:interval];
 		
 		callback = callbackp;
 		JSValueProtect([WizCanvasView instance].jsGlobalContext, callback);
@@ -61,17 +66,16 @@
 
 - (void)dealloc {
 	JSValueUnprotect([WizCanvasView instance].jsGlobalContext, callback);
+    self.target = nil;
 	[super dealloc];
 }
 
 - (void)check {
-	NSTimeInterval currentTime = [NSDate timeIntervalSinceReferenceDate];
-	
-	if( active && target <= currentTime ) {
+	if( active && [self.target timeIntervalSinceNow] <= 0 ) {
 		[[WizCanvasView instance] invokeCallback:callback thisObject:NULL argc:0 argv:NULL];
 		
 		if( repeat ) {
-			target = currentTime + interval;
+            self.target = [NSDate dateWithTimeIntervalSinceNow:interval];
 		}
 		else {
 			active = false;


### PR DESCRIPTION
- Previous implementation only worked with -O0.  When any optimization setting
  other than -O0 was used, some timers with an interval of 1.0 would fire every
  frame instead of every second.  This change resolves that problem and  allows
  timers to work with -O1 and -Os optimization settings.

Reviewer: @aogilvie
