### PR TITLE
added zooming controls to android WebView

### DIFF
--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/wizViewManager/WizWebView.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/wizViewManager/WizWebView.java
@@ -80,7 +80,11 @@ public class WizWebView extends WebView  {
         webSettings.setJavaScriptEnabled(true);
         
         webSettings.setDomStorageEnabled(true);
-
+        // Whether or not on-screen controls are displayed can be set with setDisplayZoomControls(boolean). 
+        // The default is false.
+        // The built-in mechanisms are the only currently supported zoom mechanisms, 
+        // so it is recommended that this setting is always enabled.
+        webSettings.setBuiltInZoomControls(true);
         webSettings.setLoadWithOverviewMode(true);
         webSettings.setUseWideViewPort(true);
 


### PR DESCRIPTION
### Testing:

To test that pinch zoom and double tap are working, load the example project and use create & show view APIs.

Te test that this can be disabled by meta modify the create API in index.html in the example project to `src: "file:///android_asset/www/customview.html"`.

The customview.html includes `user-scalable=no` which will override the zoom controls. 
